### PR TITLE
Fix extension retrieval in EbayImagesPipeline

### DIFF
--- a/scraping-ebay-1.0.3/scraping_ebay/pipelines.py
+++ b/scraping-ebay-1.0.3/scraping_ebay/pipelines.py
@@ -33,7 +33,9 @@ class EbayImagesPipeline(ImagesPipeline):
         """
         sw_code = request.meta.get('sw_code')
         order   = request.meta.get('order')
-        ext = os.path.splitext(request.url)[1].split('?')[0] or '.jpg' , '.webp'
+        ext = os.path.splitext(request.url)[1].split('?')[0]
+        if not ext:
+            ext = '.jpg'
         filename = f"{sw_code}_{order}{ext}"
         return f"{sw_code}/{filename}"
 

--- a/scraping-ebay-1.0.3/utils/jsons_to_csv.py
+++ b/scraping-ebay-1.0.3/utils/jsons_to_csv.py
@@ -2,26 +2,31 @@ import os
 import shutil
 import pandas as pd
 import json
-allpaths=[]
-print("getting all json files")
-for root, directories, files in os.walk("./", topdown=False):
-    for name in files:
-        f=(os.path.join(root, name))
-        if f.endswith((".json")):
-            allpaths.append(f)
-            
-dflist=[]
-for filepath in allpaths:
-    
-    filename=(os.path.basename(filepath))
-    filename=filename.split(".")[0]
-    with open(filepath) as json_file:
-        data = json.load(json_file)
+def main():
+    allpaths = []
+    print("getting all json files")
+    for root, directories, files in os.walk("./", topdown=False):
+        for name in files:
+            f = os.path.join(root, name)
+            if f.endswith(".json"):
+                allpaths.append(f)
 
-    df = pd.DataFrame(data, index=[0])
-    df["prod_id"]=filename
-    dflist.append(df)
-df1 = pd.concat(dflist,axis=0, ignore_index=True)
-df1 = df1[ ['prod_id'] + [ col for col in df1.columns if col != 'prod_id' ] ]
-df1.to_csv("spects.csv")
-print("CSV file generated")
+    dflist = []
+    for filepath in allpaths:
+        filename = os.path.basename(filepath)
+        filename = filename.split(".")[0]
+        with open(filepath) as json_file:
+            data = json.load(json_file)
+
+        df = pd.DataFrame(data, index=[0])
+        df["prod_id"] = filename
+        dflist.append(df)
+
+    df1 = pd.concat(dflist, axis=0, ignore_index=True)
+    df1 = df1[["prod_id"] + [col for col in df1.columns if col != "prod_id"]]
+    df1.to_csv("spects.csv")
+    print("CSV file generated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pipeline_ext.py
+++ b/tests/test_pipeline_ext.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pytest
+from scrapy.http import Request
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scraping-ebay-1.0.3'))
+from scraping_ebay.pipelines import EbayImagesPipeline
+
+
+def test_file_path_uses_correct_extension():
+    pipeline = EbayImagesPipeline(store_uri="/tmp")
+    req = Request('http://example.com/img1.png?size=large', meta={'sw_code': 'abc', 'order': 1})
+    assert pipeline.file_path(req) == 'abc/abc_1.png'
+
+
+def test_file_path_defaults_to_jpg_when_no_extension():
+    pipeline = EbayImagesPipeline(store_uri="/tmp")
+    req = Request('http://example.com/img', meta={'sw_code': 'xyz', 'order': 2})
+    assert pipeline.file_path(req) == 'xyz/xyz_2.jpg'


### PR DESCRIPTION
## Summary
- fix `ext` variable in `EbayImagesPipeline.file_path`
- guard utils script execution behind `if __name__ == '__main__'`
- add tests for pipeline file path logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c96a57b9883339a6d62d439e4d567