### PR TITLE
Fix default image store env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This project contains a small Scrapy setup used to download product images from 
 
 Two environment variables control where the spider reads the product links and where it stores images:
 
-- `CSV_LINKS_PATH` – path to the CSV file with the columns `SW_Code` and `Item_Link`. It defaults to `../EBay_links_output.csv`.
-- `IMAGES_STORE` – directory that receives the downloaded images. It defaults to `./downloaded_images`.
+- `CSV_LINKS_PATH` – path to the CSV file with the columns `SW_Code` and `Item_Link`. It defaults to `D:\Ebay_Scraper\EBay_links_output.csv`.
+- `IMAGES_STORE` – directory that receives the downloaded images. It defaults to `D:\Ebay_Scraper\Ebay_pics`.
 
 ## Usage
 

--- a/scraping-ebay-1.0.3/scraping_ebay/settings.py
+++ b/scraping-ebay-1.0.3/scraping_ebay/settings.py
@@ -13,10 +13,7 @@ CSV_LINKS_PATH = os.getenv(
 )
 
 # Basis-Verzeichnis zum Speichern heruntergeladener Bilder
-IMAGES_STORE = os.getenv(
-    'file_path',
-    r'D:\Ebay_Scraper\Ebay_pics'
-)
+IMAGES_STORE = os.getenv('IMAGES_STORE', r'D:\Ebay_Scraper\Ebay_pics')
 
 # Aktiviere deine Bilder-Pipeline
 ITEM_PIPELINES = {


### PR DESCRIPTION
## Summary
- use `IMAGES_STORE` environment variable for default image path
- update README to show new default CSV and image locations

## Testing
- `pytest -q` *(fails: ValueError: No objects to concatenate)*

------
https://chatgpt.com/codex/tasks/task_e_686c97afd7948333ad9cb7e808f7d344